### PR TITLE
Borg hypo change and balance.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules_vr.dm
@@ -90,11 +90,6 @@
 	R.old_x  	 = -16
 	..()
 
-/obj/item/weapon/robot_module/robot/medical/surgeon/New()
-	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
-
-/obj/item/weapon/robot_module/robot/medical/crisis/New()
-	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
 
 /obj/item/weapon/robot_module/ert
 	name = "Emergency Responce module"

--- a/code/modules/mob/living/silicon/robot/robot_modules_yw.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules_yw.dm
@@ -6,6 +6,7 @@
 
 /obj/item/weapon/robot_module/xenomaid
 	name = "Xenomorph Maid module"
+	channels = "Service"
 	sprites = list(
 					"Xenomorph Maid" = "xenomaid"
 					)
@@ -31,12 +32,11 @@
 	sprites = list(
 					"Blade" = "blade",
 					)
-	channels = list("Security" = 1)
+	channels = list("Supply" = 1)
 	networks = list(NETWORK_MINE)
 	can_be_pushed = 0
 
 /obj/item/weapon/robot_module/blade/New(var/mob/living/silicon/robot/R)
-	src.modules += new /obj/item/device/flash(src)
 	src.modules += new /obj/item/weapon/dogborg/jaws/big(src) //In case there's some kind of hostile mob.
 	src.modules += new /obj/item/device/dogborg/boop_module(src) //Boop people on the nose.
 	src.modules += new /obj/item/device/dogborg/tongue(src) //This is so they can clean up bloody evidence after it's examined, and so they can lick crew.

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -9,11 +9,11 @@
 	possible_transfer_amounts = null
 
 	var/mode = 1
-	var/charge_cost = 50
+	var/charge_cost = 325
 	var/charge_tick = 0
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
-	var/list/reagent_ids = list("tricordrazine", "inaprovaline", "Bicaridine", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
+	var/list/reagent_ids = list("tricordrazine", "inaprovaline", "bicaridine", "anti_toxin", "kelotane", "tramadol", "dexalin" ,"spaceacillin")
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
@@ -21,7 +21,7 @@
 	reagent_ids = list("tricordrazine", "inaprovaline", "oxycodone", "dexalin" ,"spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/crisis
-	reagent_ids = list("tricordrazine", "inaprovaline", "Bicaridine","anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
+	reagent_ids = list("tricordrazine", "inaprovaline", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/New()
 	..()
@@ -47,8 +47,11 @@
 		if(R && R.cell)
 			for(var/T in reagent_ids)
 				if(reagent_volumes[T] < volume)
-					R.cell.use(charge_cost)
-					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
+					if(R.cell.charge - charge_cost < 800) //This is so borgs don't kill themselves with it.
+						return 0
+					else
+						R.cell.use(charge_cost)
+						reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
 /obj/item/weapon/reagent_containers/borghypo/attack(var/mob/living/M, var/mob/user)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -13,7 +13,7 @@
 	var/charge_tick = 0
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
-	var/list/reagent_ids = list("tricordrazine", "inaprovaline", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
+	var/list/reagent_ids = list("tricordrazine", "inaprovaline", "Bicaridine", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
 	var/list/reagent_volumes = list()
 	var/list/reagent_names = list()
 
@@ -21,7 +21,7 @@
 	reagent_ids = list("tricordrazine", "inaprovaline", "oxycodone", "dexalin" ,"spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/crisis
-	reagent_ids = list("tricordrazine", "inaprovaline", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
+	reagent_ids = list("tricordrazine", "inaprovaline", "Bicaridine","anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/New()
 	..()


### PR DESCRIPTION
-fixed the surgeon and crisis borg. again. (looks like it got added to the base file, but not removed from the VR file. which is causing runtimes still.

-Added bicard and kelo to the canine-hypo, based on the med belly has both, allowing for basic healing in all 4 areas to people that refuse to be mednommed.
-(this also has a (Rather expensive, see below) side effect of been able to slow internal bleeding with a bicard OD. though this would cost the borg a -lot- of power to synthesis it all, and would likely be a last ditch effort thing.)

-Because of this buff to the hypo, i've brought up the power cost of it to be inline with the medbelly, from 50 power per use, to 325. There's no power gain or loss to preferring one over the other, but the medbelly is able to heal more specific things, such as eye or brain damage, and is much more efficient at keeping someone stable if critical, so the belly still has its advantages over hypo. (not to mention the belly can go though suits, where the hypo cannot.)

-added a check to hypo to stop it from killing the borg by draining its battery, this check is silent, and will not warn the borg in question unlike the medical belly, (unless you wanted to spam them every 5 seconds with said warning), if a chem recharge would bring them under 1000 power or so, it'll halt chemical production, same as medbelly.

