### PR TITLE
Remove nuticost and 'glideyness' for wings. Add ability to bite self with numbing bites.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -146,7 +146,6 @@ var/const/enterloopsanity = 100
 		if(M.lastarea.has_gravity == 0)
 			inertial_drift(M)
 		if(M.flying) //VORESTATION Edit Start. This overwrites the above is_space without touching it all that much.
-			inertial_drift(M)
 			M.make_floating(1) //VOREStation Edit End.
 		else if(!is_space())
 			M.inertia_dir = 0

--- a/code/modules/mob/living/carbon/human/species/species_attack_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack_vr.dm
@@ -11,8 +11,11 @@
 
 	attack_damage = Clamp(attack_damage, 1, 5)
 	if(target == user)
-		user.visible_message("<span class='danger'>[user] [pick(attack_verb)] \himself in the [affecting.name]!</span>")
-		return 0 //No venom for you.
+		user.visible_message("<span class='danger'>[user] sinks their fangs in to themself in the [affecting.name]!</span>")
+		to_chat(target, "<font color='red'><b>You feel a wave of numbness as you sink your fangs in to yourself.</b></font>")
+		target.bloodstr.add_reagent("numbenzyme",attack_damage) //Yawn-edit. Allows adding venom to self.
+		return 0
+
 	switch(zone)
 		if(BP_HEAD, O_MOUTH, O_EYES)
 			// ----- HEAD ----- //

--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -766,7 +766,7 @@
 
 	if(!C.anchored && !C.pulledby) //Not currently anchored, and not pulled by anyone.
 		C.anchored = 1 //This is the only way to stop the inertial_drift.
-		C.nutrition -= 25
+		C.nutrition -= 10
 		update_floating()
 		to_chat(C, "<span class='notice'>You hover in place.</span>")
 		spawn(6) //.6 seconds.

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -165,8 +165,8 @@
 	if(ismob(src))
 		var/mob/H = src //VOREStation Edit Start. Flight on mobs.
 		if(H.flying) //Some other checks are done in the wings_toggle proc
-			if(H.nutrition > 2)
-				H.nutrition -= 2 //You use up 2 nutrition per TILE and tick of flying above open spaces. If people wanna flap their wings in the hallways, shouldn't penalize them for it.
+			//if(H.nutrition > 2) YAWNedit: Removing nutritional costs. leaving code commented for integrity incase it should be brought back.
+			//	H.nutrition -= 2 //You use up 2 nutrition per TILE and tick of flying above open spaces. If people wanna flap their wings in the hallways, shouldn't penalize them for it.
 			if(H.incapacitated(INCAPACITATION_ALL))
 				H.stop_flying()
 				//Just here to see if the person is KO'd, stunned, etc. If so, it'll move onto can_fall.
@@ -175,7 +175,7 @@
 				H.stop_flying() //womp womp.
 			else if(H.nutrition < 300 && H.nutrition > 289) //290 would be risky, as metabolism could mess it up. Let's do 289.
 				to_chat(H, "<span class='danger'>You are starting to get fatigued... You probably have a good minute left in the air, if that. Even less if you continue to fly around! You should get to the ground soon!</span>") //Ticks are, on average, 3 seconds. So this would most likely be 90 seconds, but lets just say 60.
-				H.nutrition -= 10
+				//H.nutrition -= 10 YAWNedit: im sorry..10 nuticost a tick in this area? what? O_o
 				return
 			else if(H.nutrition < 100 && H.nutrition > 89)
 				to_chat(H, "<span class='danger'>You're seriously fatigued! You need to get to the ground immediately and eat before you fall!</span>")


### PR DESCRIPTION
### turf.dm movement.dm station/station_special_abilities_vr.dm
Changes to files for flight trait:
 - Removed nutriment cost. it was far too high for something that was just mostly for flash and show.
 - Removed the whole..sliding around while flying. if your a creature that can fly, you should be more incontrol of that shit.
    - However, if your not paying attention, bumping in to walls and stuff does still happen, and will still knock you down and out of flying. but now its *your fault*, not the sliding.

### species/species_attack_vr.dm

- Changes made to the numbing bite attack
 - Can now attack self, and inject self with the venom to numb your own pain
   - Keeping an eye on this change, potential to be OP if abused, but there are work arounds for it, which cause it to be more OP with the correct tools. at least this way, the bite will cause the user injury on use.

 - Possible thoughts and notes for future: Traits that change the chemical injected on bite? perhaps a bite that actually causes injury/halucinations. Aphro? (hahah.) plenty of untapped ideas for a venom bite, really, both healing and..venomous.