### PR TITLE
Proper "Aphro"

### DIFF
--- a/code/modules/reagents/kelshark.dm
+++ b/code/modules/reagents/kelshark.dm
@@ -54,8 +54,6 @@ datum
 		drug_strength = drug_strength * 0.6
 	M.make_dizzy(drug_strength)
 	M.Confuse(drug_strength * 14)
-	M.adjustOxyLoss(25 * removed)
-	M.sleeping += 1
 
 
 /obj/item/weapon/reagent_containers/pill/benzilate

--- a/code/modules/reagents/kelshark.dm
+++ b/code/modules/reagents/kelshark.dm
@@ -1,17 +1,20 @@
 datum
 	reagent
+// Shamelessly ripped from Y.W., with large changes. -Carl
+		benzilate
+			name = "Odd Goo"
+			id = "benzilate"
+			description = "Grey... goo? This smells like hot acid. Consuming this likely wouldn't be good for your health."
+			taste_description = "raw iron"
+			taste_mult = 0.4
+			metabolism = REM * 2.5
+			color = "#929292"
 
-		customchem
-			name = "Odd Chemical"
-			id = "customchem"
-			description = "Weird thing."
-			color = "#FFFF99"
-
-		hornychem
-			name = "Aphrodisiac"
-			id = "hornychem"
-			description = "You so horny."
-			color = "#FF9999"
+		phenethylamine
+			name = "Phenethylamine"
+			id = "phenethylamine"
+			description = "Just looking at this makes you feel odd. Whether or not this would be good to consume is likely a gamble."
+			color = "#463667"
 			data = list("count"=1)
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
@@ -29,16 +32,78 @@ datum
 				//..()
 				return
 
-/datum/chemical_reaction/customchem
-	name = "Customchem"
-	id = "customchem"
-	result = "customchem"
-	required_reagents = list("water" = 1, "tungsten" = 1)
+/datum/chemical_reaction/benzilate
+	name = "Benzilate"
+	id = "benzilate"
+	result = "benzilate"
+	required_reagents = list("paracetamol" = 1, "mindbreaker" = 1)
 	result_amount = 2
 
-/datum/chemical_reaction/hornychem
-	name = "Hornychem"
-	id = "hornychem"
-	result = "hornychem"
-	required_reagents = list("water" = 1, "customchem" = 1)
+/datum/chemical_reaction/phenethylamine
+	name = "Phenethylamine"
+	id = "phenethylamine"
+	result = "phenethylamine"
+	required_reagents = list("paroxetine" = 1, "benzilate" = 1)
 	result_amount = 2
+
+/datum/reagent/benzilate/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien == IS_DIONA)
+		return
+	var/drug_strength = 12
+	if(alien == IS_SKRELL)
+		drug_strength = drug_strength * 0.6
+	M.make_dizzy(drug_strength)
+	M.Confuse(drug_strength * 14)
+	M.adjustOxyLoss(25 * removed)
+	M.sleeping += 1
+
+
+/obj/item/weapon/reagent_containers/pill/benzilate
+	name = "Benzilate pill"
+	desc = "You probably shouldn't swallow this."
+	icon_state = "pill2"
+
+/obj/item/weapon/reagent_containers/pill/benzilate/New()
+	..()
+	reagents.add_reagent("benzilate", 50)
+
+
+/obj/item/weapon/reagent_containers/pill/phenethylamine
+	name = "Phenethylamine pill"
+	desc = "Smells like... lilacs?"
+	icon_state = "pill5"
+
+/obj/item/weapon/reagent_containers/pill/phenethylamine/New()
+	..()
+	reagents.add_reagent("phenethylamine", 50)
+
+
+// PILLS THAT WE PROBABLY SHOULDN'T HAVE AAAAAAAAAA. The below is only so they can be included through mapping or "spawn " command. -Carl
+
+/obj/item/weapon/storage/pill_bottle/benzilate
+	name = "bottle of Benzilate pills"
+	desc = "This just hurts to look at with how many words of caution are scrawled on the lable. Better eat all of 'em!"
+
+/obj/item/weapon/storage/pill_bottle/benzilate/New()
+	..()
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+	new /obj/item/weapon/reagent_containers/pill/benzilate( src )
+
+/obj/item/weapon/storage/pill_bottle/phenethylamine
+	name = "bottle of Phenethylamine pills"
+	desc = "Looks like someone drew a happy face on the label, replacing whatever was previously present."
+
+/obj/item/weapon/storage/pill_bottle/phenethylamine/New()
+	..()
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )
+	new /obj/item/weapon/reagent_containers/pill/phenethylamine( src )


### PR DESCRIPTION
Actually makes this a proper thing, rather than what had been previously done.
Gives players the ability to create it through a process, removing the water+tungsten spam that was previously used.