### PR TITLE
R-UST Engine and Guide rework

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -221,9 +221,10 @@
 /obj/item/weapon/book/manual/rust_engine
 	name = "R-UST Operating Manual"
 	icon_state = "bookSupermatter"
-	author = "Cindy Crawfish"
+	author = "Yumi Kruik"
 	title = "R-UST Operating Manual"
 
+//R-UST guide Re-Writen by Gozulio to reflect how the R-UST actually operates.
 /obj/item/weapon/book/manual/rust_engine/New()
 	..()
 	dat = {"<html>
@@ -240,14 +241,22 @@
 				<body>
 				<br><br>
 				<ol>
-				<li>Put uranium in the portable generator near the gyrotron and turn it to full. This is to provide initial power to the core.</li>
-				<li>Enable and max output on the SMES in the engine room. This is to power the gyrotron.</li>
-				<li>Go into the control room, interact with the fusion core control console. Turn the field on and raise size to 501. Any bigger and it will start EMPing the doors. Any smaller and the fuel pellets might miss.</li>
-				<li>Interact with the gyrotron control computer, set power as high as the SMES can support, usually around 4, and turn it on. This will start increasing the plasma temperature to the point where reactions can occur.</li>
-				<li>Go into the engine room and insert a deuterium fuel assembly and a tritium fuel assembly into two of the fuel injectors. You can make deuterium rods in the fuel compressor if you want to play it safe.</li>
-				<li>Go back to the control room and turn the fuel injectors on. This will start firing pellets into the field.</li>
-				<li>Wait for reactions to start (plasma temperature will spike and fuel amounts will drop). Turn the gyrotron power down until it's keeping up with field instability. This will prevent cumulative instability from the deuterium-tritium reaction fucking up the field. If you're using straight deuterium instability isn't a problem and you can turn the gyrotron off.</li>
-				<li>Configure the SMES, turn the PACMAN off before it explodes.</li>
+				<li>Go to engine gas storage to the south of the engine room and fetch two Canisters of Nitrogen. and two canisters of Phoron.</li>
+				<li>Secure the Phoron canister to the port that pumps into the Cold (Green/Cyan) loop, and the Nitrogen canister into the Hot(Yellow/Red) loop. long story short, The reactor doesn't like Phoron.</li>
+				<li><b>DO NOT OPEN THE VALVE ON THE GAS CANISTERS, OR SPACE GOD WILL HATE YOU.</b> Turn both pumps on to maximum input, Swap the canisters for full ones when necesary. Each loop only needs 2 canisters of gas.</li>
+				<li>Turn on the pump just to the West of the Pump Station and set it to maximum pressure.</li>
+				<li>Now Coolant is flowing, lets actually start the reactor.</li>
+				<li>Go into the Engine Monitoring room and open the Reactor Shroud, and close the Monitoring room Blast Doors.</li>
+				<li>Get the PACMAN from hard storage and Secure it in the Engine SMES room, and load it with Phoron.</li>
+				<li>Enable max input and output on the engine SMES and shut off the input off on the Station SMES. This is to make sure the gyrotron gets as much power as it can during start up.</li>
+				<li>Turn the PACMAN on, setting it to power 4/5.</li>
+				<li>Go into the reactor Control Room (East of the reactor) and take the stack of Deuterium off the table, and click it on the compressor twice, this should make two Deuterium Fuel rods. You can ignore the Tritium.</li>
+				<li>In the Control room go to the Core Control console, Access the field, and set its strength/size to 600. This will give you a field of about 7x7 tile. Note the field size, A bigger field can EMP machinery or doors around it, a smaller field may allow Gyrotron shots to miss, and punch holes in the back wall.</li>
+				<li>In the Control room go to the Gyrotron Control console and turn the gyrotrons on, delay 3 power 3.</li>
+				<li>In the Control room go to the Fuel Injector console and start injecting fuel.</li>
+				<li>Go back to the Core Control Console, and now wait for the temperature to spike from 296 Kelvin up to 3,000 to 10,000 Kelvin. When the temperature spikes it means you have achieved fusion</li>
+				<li>Now turn the Gyrotrons off, You can turn off one of the two fuel injectors as well if you wish to conserve fuel.</li>
+				<li>You should be producing power now, a lot of it. Now go turn on the Station SMES and turn off the PACMAN before it explodes.</li>
 				</ol>
 				<br>
 				<b>NOTES FOR NEWBIES</b>

--- a/maps/submaps/engine_submaps/engine_rust.dmm
+++ b/maps/submaps/engine_submaps/engine_rust.dmm
@@ -2,17 +2,17 @@
 "ab" = (/turf/space,/area/space)
 "ac" = (/obj/item/weapon/book/manual/rust_engine,/turf/template_noop,/area/template_noop)
 "ad" = (/obj/machinery/computer/general_air_control/supermatter_core{dir = 1; frequency = 1438; input_tag = "cooling_in"; name = "Engine Cooling Control"; output_tag = "cooling_out"; pressure_setting = 100; sensors = list("engine_sensor" = "Engine Core"); throwpass = 1},/turf/template_noop,/area/template_noop)
-"ae" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine charging port."; id = "SupermatterPort"; name = "Radiation Collector Blast Doors"; pixel_x = -6; pixel_y = 7; req_access = list(10)},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = 0; pixel_y = -3; req_access = list(10)},/turf/template_noop,/area/template_noop)
+"ae" = (/obj/structure/grille,/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "af" = (/obj/machinery/light{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"ag" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "engine_access_hatch"; locked = 1; name = "Fusion Core Access"; req_access = list(11)},/turf/simulated/floor,/area/engineering/engine_room)
+"ag" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "engine_access_hatch"; locked = 1; name = "Fusion Core Access"; req_access = list(11)},/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "ah" = (/obj/machinery/computer/fusion_fuel_control{id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
 "ai" = (/obj/structure/lattice,/obj/structure/grille,/turf/space,/area/space)
 "aj" = (/obj/structure/lattice,/turf/space,/area/space)
 "ak" = (/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"al" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineVent"; name = "Reactor Vent"; p_open = 0},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"al" = (/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineVent"; name = "Reactor Vent"; p_open = 0},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "am" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
-"an" = (/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"ao" = (/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/structure/grille,/turf/simulated/floor,/area/engineering/engine_room)
+"an" = (/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"ao" = (/obj/structure/grille,/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "ap" = (/turf/space,/area/engineering/engine_smes)
 "aq" = (/turf/simulated/floor,/area/engineering/engine_room)
 "ar" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor,/area/engineering/engine_room)
@@ -23,8 +23,8 @@
 "aw" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/turf/space,/area/space)
 "ax" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 4},/obj/structure/lattice,/turf/space,/area/space)
 "ay" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 10},/turf/space,/area/space)
-"az" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aA" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"az" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"aA" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "aB" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
 "aC" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/engineering/engine_room)
 "aD" = (/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor,/area/engineering/engine_room)
@@ -32,32 +32,32 @@
 "aF" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/obj/structure/lattice,/turf/space,/area/space)
 "aG" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 6},/obj/structure/lattice,/turf/space,/area/space)
 "aH" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 9},/obj/structure/lattice,/turf/space,/area/space)
-"aI" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"aI" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "aJ" = (/obj/machinery/fusion_fuel_injector/mapped{dir = 8; id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
 "aK" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
 "aL" = (/obj/machinery/computer/gyrotron_control{id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
 "aM" = (/obj/machinery/alarm{dir = 8; pixel_x = 25; pixel_y = 0},/turf/simulated/floor,/area/engineering/engine_room)
 "aN" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging,/turf/space,/area/space)
 "aO" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/turf/space,/area/space)
-"aP" = (/obj/machinery/power/fusion_core/mapped{id_tag = "engine"},/obj/structure/cable/cyan,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"aP" = (/obj/machinery/power/fusion_core/mapped{id_tag = "engine"},/obj/structure/cable/cyan,/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "aQ" = (/obj/machinery/computer/fusion_core_control{id_tag = "engine"},/turf/simulated/floor,/area/engineering/engine_room)
-"aR" = (/obj/machinery/atmospherics/unary/outlet_injector{unacidable = 1; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aS" = (/obj/machinery/air_sensor{frequency = 1438; id_tag = "engine_sensor"; output = 63},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aT" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"aR" = (/obj/machinery/atmospherics/unary/outlet_injector{unacidable = 1; use_power = 1},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"aS" = (/obj/machinery/air_sensor{frequency = 1438; id_tag = "engine_sensor"; output = 63},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"aT" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "aU" = (/obj/machinery/camera/network/engine,/obj/machinery/button/remote/airlock{id = "engine_access_hatch"; name = "Door Bolt Control"; pixel_x = -4; pixel_y = 28; req_access = list(10); specialfunctions = 4},/turf/simulated/floor,/area/engineering/engine_room)
 "aV" = (/obj/structure/table/reinforced,/obj/item/weapon/book/manual/rust_engine,/turf/simulated/floor,/area/engineering/engine_room)
-"aW" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 4; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aX" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aY" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 8; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"aZ" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"ba" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/red,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"bb" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"aW" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 4; use_power = 1},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"aX" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"aY" = (/obj/machinery/atmospherics/unary/outlet_injector{dir = 8; use_power = 1},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"aZ" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"ba" = (/obj/machinery/atmospherics/pipe/manifold4w/visible/red,/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"bb" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; pump_direction = 0; use_power = 1},/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "bc" = (/turf/simulated/wall/r_wall,/area/template_noop)
-"bd" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
-"be" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor/reinforced,/area/engineering/engine_room)
+"bd" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
+"be" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor/reinforced/airless,/area/engineering/engine_room)
 "bf" = (/obj/machinery/camera/network/engine{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
-"bg" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/structure/grille,/turf/simulated/floor,/area/engineering/engine_room)
-"bh" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/structure/grille,/turf/simulated/floor,/area/engineering/engine_room)
+"bg" = (/obj/structure/grille,/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
+"bh" = (/obj/structure/grille,/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "bi" = (/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/apc{dir = 4; name = "east bump"; pixel_x = 28},/turf/simulated/floor,/area/engineering/engine_room)
 "bj" = (/obj/machinery/power/emitter/gyrotron/anchored{dir = 1; id_tag = "engine"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
 "bk" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/turf/simulated/floor,/area/engineering/engine_room)
@@ -75,9 +75,9 @@
 "bw" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
 "bx" = (/obj/machinery/atmospherics/pipe/simple/visible/red{icon_state = "intact"; dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
 "by" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/engineering/engine_room)
-"bz" = (/turf/simulated/floor,/area/template_noop)
-"bA" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/camera/network/engine{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"bB" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
+"bz" = (/obj/structure/grille,/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 8},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
+"bA" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/structure/grille,/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
+"bB" = (/obj/structure/grille,/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "bC" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine radiator viewport shutters."; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutters"; pixel_x = -25; pixel_y = 0; req_access = list(10)},/turf/simulated/floor,/area/engineering/engine_room)
 "bD" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
 "bE" = (/obj/machinery/atmospherics/pipe/manifold/visible/yellow{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
@@ -85,7 +85,7 @@
 "bG" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 4},/obj/machinery/atmospherics/pipe/simple/visible/red,/turf/simulated/floor,/area/engineering/engine_room)
 "bH" = (/obj/machinery/atmospherics/pipe/simple/visible/yellow{dir = 10},/turf/simulated/floor,/area/engineering/engine_room)
 "bI" = (/obj/structure/cable/yellow{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor,/area/engineering/engine_room)
-"bJ" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
+"bJ" = (/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/structure/grille,/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "bK" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging{dir = 5},/obj/structure/lattice,/turf/space,/area/space)
 "bL" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/obj/structure/lattice,/turf/space,/area/space)
 "bM" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
@@ -95,17 +95,17 @@
 "bQ" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
 "bR" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
 "bS" = (/obj/machinery/atmospherics/pipe/manifold/visible/green{dir = 1},/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
-"bT" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 10; icon_state = "intact";},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
+"bT" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 10; icon_state = "intact"},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
 "bU" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
-"bV" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/manifold/visible/red{dir = 8; icon_state = "map";},/turf/simulated/floor,/area/engineering/engine_room)
+"bV" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/manifold/visible/red{dir = 8; icon_state = "map"},/turf/simulated/floor,/area/engineering/engine_room)
 "bW" = (/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/obj/structure/cable/yellow,/obj/machinery/power/sensor{name = "Powernet Sensor - Engine Output"; name_tag = "Engine Output"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor,/area/engineering/engine_room)
-"bX" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
+"bX" = (/obj/structure/grille,/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/turf/simulated/floor,/area/engineering/engine_room)
 "bY" = (/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{dir = 8},/turf/space,/area/space)
 "bZ" = (/obj/structure/grille,/obj/structure/window/reinforced/full,/obj/structure/window/reinforced{dir = 8; health = 1e+006},/obj/machinery/door/blast/regular{density = 0; icon_state = "pdoor0"; id = "EngineRadiatorViewport"; name = "Engine Radiator Viewport Shutter"; opacity = 0},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
 "ca" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 10},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
 "cb" = (/obj/machinery/atmospherics/binary/pump,/turf/simulated/floor,/area/engineering/engine_room)
 "cc" = (/obj/machinery/atmospherics/binary/pump{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
-"cd" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
+"cd" = (/obj/structure/grille,/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong, and dense"; icon_state = "phoronwindow0"; name = "high density reinforced borosilicate window"; rad_resistance = 100},/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
 "ce" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
 "cf" = (/obj/machinery/power/generator{anchored = 1; dir = 4},/obj/structure/cable/yellow{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/engineering/engine_room)
 "cg" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1},/turf/simulated/floor,/area/engineering/engine_room)
@@ -151,7 +151,7 @@
 "cU" = (/turf/simulated/floor/plating,/area/template_noop)
 "cV" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/turf/simulated/floor,/area/engineering/engine_gas)
 "cW" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineEmitterPortWest"; name = "Engine Room Blast Doors"; pixel_x = 0; pixel_y = 25; req_access = null; req_one_access = list(11,24)},/turf/simulated/floor,/area/engineering/engine_gas)
-"cX" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = 32;},/turf/simulated/floor,/area/engineering/engine_gas)
+"cX" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/carbon_dioxide,/obj/structure/extinguisher_cabinet{dir = 1; icon_state = "extinguisher_closed"; pixel_y = 32},/turf/simulated/floor,/area/engineering/engine_gas)
 "cY" = (/obj/effect/floor_decal/industrial/warning/corner,/turf/simulated/floor,/area/engineering/engine_room)
 "cZ" = (/obj/machinery/button/remote/blast_door{id = "EngineVent"; name = "Reactor Ventillatory Control"; pixel_x = 0; pixel_y = -25; req_access = list(10)},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
 "da" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
@@ -176,31 +176,44 @@
 "dt" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"; pixel_x = 0; pixel_y = 0},/turf/simulated/wall/r_wall,/area/template_noop)
 "du" = (/obj/machinery/door/firedoor/glass,/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
 "dv" = (/obj/machinery/door/firedoor/glass,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineEmitterPortWest2"; layer = 3.3; name = "Engine Gas Storage"},/turf/simulated/floor/tiled/steel_grid,/area/template_noop)
-"dw" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/engineering/engine_room)
+"dw" = (/obj/structure/grille,/obj/structure/window/phoronreinforced/full{icon_state = "phoronwindow0"},/obj/machinery/door/blast/regular{dir = 2; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/turf/simulated/floor,/area/engineering/engine_room)
 "dx" = (/obj/machinery/power/emitter/gyrotron/anchored{dir = 1; id_tag = "engine"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor,/area/engineering/engine_room)
 "dy" = (/obj/machinery/power/emitter/gyrotron/anchored{dir = 1; id_tag = "engine"},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
+"dz" = (/obj/machinery/atmospherics/pipe/simple/visible/green,/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
+"dA" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/wall/r_wall,/area/engineering/engine_room)
+"dB" = (/obj/machinery/camera/network/engine{dir = 4},/turf/simulated/floor,/area/engineering/engine_room)
+"dC" = (/obj/machinery/button/remote/blast_door{desc = "A remote control-switch for the engine control room blast doors."; id = "EngineBlast"; name = "Engine Monitoring Room Blast Doors"; pixel_x = 0; pixel_y = -3; req_access = list(10)},/obj/machinery/button/remote/blast_door{id = "EngineShroud"; name = "Reactor Shroud Control"; pixel_x = 4; pixel_y = 4; req_access = list(10)},/turf/template_noop,/area/template_noop)
+"dD" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
+"dE" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/visible/yellow,/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
+"dF" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
+"dG" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
+"dH" = (/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/pipe/simple/visible/red,/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
+"dI" = (/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 1},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong and dense."; dir = 8; icon_state = "phoronrwindow"; name = "high density reinforced borosilicate window"; rad_resistance = 25},/turf/simulated/floor,/area/template_noop)
+"dJ" = (/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong and dense."; dir = 8; icon_state = "phoronrwindow"; name = "high density reinforced borosilicate window"; rad_resistance = 25},/turf/simulated/floor,/area/template_noop)
+"dK" = (/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 4},/obj/structure/window/phoronreinforced/full{icon_state = "phoronrwindow"; dir = 2},/obj/structure/window/phoronreinforced/full{desc = "A borosilicate alloy window, with rods supporting it. It seems to be very strong and dense."; dir = 8; icon_state = "phoronrwindow"; name = "high density reinforced borosilicate window"; rad_resistance = 25},/turf/simulated/floor,/area/template_noop)
+"dM" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/door/blast/regular{dir = 4; icon_state = "pdoor1"; id = "EngineShroud"; name = "Reactor Shroud"; p_open = 0; rad_resistance = 0},/obj/effect/floor_decal/industrial/warning{icon_state = "warning"; dir = 4},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/engineering/engine_room)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaabababababababababababababababababababababababababababaaaa
 aaabababababababababababababababababababababababababababaaaa
 aaaiaiaiaiaiajaiaiaiakakakakalakakakakakakakakakakamababaaaa
-aaaiababababajapababakanananananananaoaUafarasatauakababaaaa
+aaaiababababajapababakanananananananaeaUafarasatauakababaaaa
 aaaiabavawawaxawawayakanananazaAaAaAagaCaDaEaqaqaqakababaaaa
 aaajajaFaGaxaxaxaxaHakanananaIanananaoaJaKaraLaqaMakababaaaa
-aaaiabaNaOawaxawawayakanananaPanananaoaJaKaraQaqaqakababaaaa
-aaaiajaFaGaxaxaxaxaHakanaRanaSanaTanaoaJaKarahaqaVakababaaaa
-aaaiabaNaOawaxawawayakaWaXaYanaZbabbaoaqaKararararbcbcbcaaaa
-aaaiajaFaGaxaxaxaxaHakanbdanananbeanaoaqaKaqaqaqbfbcaaaaaaaa
-aaaiabaNaOawaxawawayakaobgaoaoaobhaoakaqaKaqaqaqbibcaaaaaaaa
-aaaiajaFaGaxaxaxaxaHakdxbpbjbqbjbrdyaqaqbmaCaCaCbnboaaaaaaaa
-aaaiabaNaOawaxawawayakbAbBbJbXbJdwbJaCaCbsaqaqaqbtboaaaaaaaa
+aaaiabaNaOawaxawawayakanananaPanananbgaJaKaraQaqaqakababaaaa
+aaaiajaFaGaxaxaxaxaHakanaRanaSanaTanbgaJaKarahaqaVakababaaaa
+aaaiabaNaOawaxawawayakaWaXaYanaZbabbbgaqaKararararbcbcbcaaaa
+aaaiajaFaGaxaxaxaxaHakanbdanananbeanbhaqaKaqaqaqbfbcaaaaaaaa
+aaaiabaNaOawaxawawayakbzbAbBbBbBbJbXcdaqaKaqaqaqbibcaaaaaaaa
+aaaiajaFaGaxaxaxaxaHakdxbpbjbqbjbrdydwaqbmaCaCaCbnboaaaaaaaa
+aaaiabaNaOawaxawawayakdDdEdFdGdFdHdMdAaCbsaqaqaqbtboaaaaaaaa
 aaaiajaFaGaxaxaxaxaHakaBbkaqaqaqblaqaqaqaqaqaqaqbubcbcbcaaaa
-aaaiabaNaOawaxawawayakaqbkaqaqaqbvbwbwbwbwbxaqaqbybzacadaaaa
-aaajajaFaGaxaxaxaxaHakbCbDbEbFbFbFbFbFbFbFbGbFbHbIbzaaaaaaaa
-aaajajaFbKaxaxaxaxbLbMbNbObObPbQbRbRbSbTbUbVbxbkbWbzaaaeaaaa
-aaaiabaNavawaxawawbYbZcacbcccccbaqaqcdcecfcgchbkcibzaaaaaaaa
-aaaiajaFbKaxaxaxaxcjckclcmcncncmaqcocpcqcrcsctcucvbzaaaaaaaa
+aaaiabaNaOawaxawawayakdBbkaqaqaqbvbwbwbwbwbxaqaqbydIacadaaaa
+aaajajaFaGaxaxaxaxaHakbCbDbEbFbFbFbFbFbFbFbGbFbHbIdJaaaaaaaa
+aaajajaFbKaxaxaxaxbLbMbNbObObPbQbRbRbSbTbUbVbxbkbWdJaadCaaaa
+aaaiabaNavawaxawawbYbZcacbcccccbaqaqdzcecfcgchbkcidJaaaaaaaa
+aaaiajaFbKaxaxaxaxcjckclcmcncncmaqcocpcqcrcsctcucvdKaaaaaaaa
 aaaiabaNavawaxawawcwamcxcycyczcycycAcBbTbUcCcDcEcFbcbcbcaaaa
 aaaiajaFbKaxaxaxaxcjcGcHcIcJcJcKcHcLcMcecfcgchbkcNbcaaaaaaaa
 aaaiabaNavawaxawawcwcGcGcGcOcOcGcGcPcQcRcrcsctcScTcUaaaaaaaa


### PR DESCRIPTION
Changes to Manuals.dm
Rewrote R-UST guide to actually match common R-UST setup on yawn.

Changes to the R-UST Engine submap.
Replaced R-UST chamber reinforced floor with Reinforced Airless floor.
Added a blast door Shroud for the R-UST,
added more Borosilicate glass around the engine monitoring room and
reactor core, as standard reinforced glass doesn't block radiation.
Mapped special "High Density Borosilicate Glass" that blocks a lot of radiation. (Blocks all radiation from Deuterium fusion, Doesn't block all radiation from Deuterium/Tritium fusion.)
Removed pointless "Radiation Collector blast doors" button that does
nothing.

I had plans to use special blast doors to shut out the radiation but that requires coding a new type of blast doors. The changes as they stand make it so that the engine SMES room, Monitoring room, and the Engine room airlock don't get flooded with Radiation by engineers that just wan't to get power running. The new guide also details the step by step process for starting the R-UST without blowing everything up.
![27bf8d9974d3fe2853ff683ec77192a7](https://user-images.githubusercontent.com/10771387/41497348-c6465c88-7121-11e8-9220-9e33414ac51f.png)
