### PR TITLE
Blueshield tweaks and map_template.dm typo fix

### DIFF
--- a/code/game/jobs/job/blueshield.dm
+++ b/code/game/jobs/job/blueshield.dm
@@ -14,12 +14,10 @@
 	ideal_character_age = 32 		//Experienced, but physically in their prime
 	minimal_player_age = 3
 	economic_modifier = 8
-	access = list(access_security, access_sec_doors, access_brig, access_forensics_lockers,
-			            access_medical, access_engine, access_change_ids, access_eva, access_heads, access_teleporter,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
-			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway, )
-	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_construction, access_engine, access_maint_tunnels, access_research, access_RC_announce, access_keycard_auth, access_heads)
+	access = list(access_security, access_sec_doors, access_brig,
+			            access_medical, access_eva, access_heads, access_teleporter,
+			            access_maint_tunnels, access_morgue,
+			            access_crematorium, access_research, access_hop, access_RC_announce, access_keycard_auth, access_gateway)
+	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_maint_tunnels, access_RC_announce, access_keycard_auth, access_heads)
 
 	outfit_type = /decl/hierarchy/outfit/job/blueshield

--- a/code/game/objects/structures/crates_lockers/closets/secure/closets_yw.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/closets_yw.dm
@@ -33,5 +33,6 @@
 		/obj/item/weapon/gun/projectile/shotgun/pump,
 		/obj/item/weapon/storage/box/beanbags,
 		/obj/item/weapon/storage/box/shotgunshells,
-		/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos
+		/obj/item/weapon/storage/secure/briefcase/nsfw_pack_hos,
+		/obj/item/weapon/gun/energy/x01
 		)

--- a/code/modules/maps/tg/map_template.dm
+++ b/code/modules/maps/tg/map_template.dm
@@ -140,7 +140,7 @@ var/list/global/map_templates = list()
 
 /datum/map_template/proc/annihilate_bounds(turf/origin, centered = FALSE)
 	var/deleted_atoms = 0
-	admin_notice("<span class='danger'>Annihilating objects in submap loading locatation.</span>", R_DEBUG)
+	admin_notice("<span class='danger'>Annihilating objects in submap loading location.</span>", R_DEBUG)
 	var/list/turfs_to_clean = get_affected_turfs(origin, centered)
 	if(turfs_to_clean.len)
 		for(var/turf/T in turfs_to_clean)


### PR DESCRIPTION
- Removes access to most of blueshield, due to them having way too much access.
- Gives the X01 back to blueshield since the NSFW is broken, again.

Also fixes a typo in map_template