### PR TITLE
Fixing player selected engine outright deleting mobs.

### DIFF
--- a/code/controllers/subsystems/mapping_yw.dm
+++ b/code/controllers/subsystems/mapping_yw.dm
@@ -27,6 +27,7 @@
 			if(istype(MT))
 				engine_types += MT
 		chosen_type = pick(engine_types)
+	global_announcer.autosay("Engineering has selected [chosen_type.name] as todays engine.", "Engine Constructor")
 	to_world_log("Chose Engine Map: [chosen_type.name]")
 	admin_notice("<span class='danger'>Chose Engine Map: [chosen_type.name]</span>", R_DEBUG)
 

--- a/maps/submaps/engine_submaps_yw/engine_yw.dm
+++ b/maps/submaps/engine_submaps_yw/engine_yw.dm
@@ -23,7 +23,7 @@
 /obj/effect/landmark/engine_loader_pickable/proc/annihilate_bounds()
 	var/deleted_atoms = 0
 	var/killed_mobs = 0
-	admin_notice("<span class='danger'>Annihilating objects in engine loading locatation.</span>", R_DEBUG)
+	admin_notice("<span class='danger'>Annihilating objects in engine loading location.</span>", R_DEBUG)
 	var/list/turfs_to_clean = get_turfs_to_clean()
 	if(turfs_to_clean.len)
 		for(var/x in 1 to 2) // Delete things that shouldn't be players.

--- a/maps/submaps/engine_submaps_yw/engine_yw.dm
+++ b/maps/submaps/engine_submaps_yw/engine_yw.dm
@@ -39,7 +39,7 @@
 		for(var/turf/T in turfs_to_clean) //now deal with those pesky mobs.
 			for(var/mob/living/LH in T)
 				if(istype(LH, /mob/living))
-					to_chat(LH, "<span class='danger'>It fels like you're being torn apart!</span>")
+					to_chat(LH, "<span class='danger'>It feels like you're being torn apart!</span>")
 					LH.apply_effect(20, AGONY, 0, 0)
 					LH.visible_message("<span class='danger'>[LH.name] is ripped apart by something you can't see!</span>")
 					LH.gib() //Murder them horribly!


### PR DESCRIPTION
Engine selector now Gibs /mob/living, and ignores /mob/observer atoms.
Engine selector waits for 30 seconds before spawning an engine.
Engine Loader Annihilate proc now alerts admins when it deletes or Gibs a mob.
Engine selector warns over engineering radio that an engine is about to spawn.
Engine selector states over common what engine was selected.