### PR TITLE
Engine Loader now calls Build_Network() on atmos machines.

### DIFF
--- a/code/controllers/subsystems/mapping_yw.dm
+++ b/code/controllers/subsystems/mapping_yw.dm
@@ -36,5 +36,5 @@
 	//CHECK_TICK //Don't let anything else happen for now
 	// Actually load it
 	chosen_type.load(T)
-	sleep(10)
+	sleep(1)
 	engine_loader_pickable.lateload_init()


### PR DESCRIPTION
Should more properly fix #168 by making Atmos initialize and rebuild networks after all Atmos machine are placed.
Also adds a few comments to document the rest of the Engine Select and Pickable Engine Loader code.